### PR TITLE
cli

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           pip install uv
           uv venv
-          uv pip install -e .[dev] || echo "No dev extra"
+          uv pip install -e .[dev,cli] || echo "No dev extra"
           echo "Dependencies installed successfully"
 
       - name: Setup git

--- a/bib_dedupe/bib_dedupe.py
+++ b/bib_dedupe/bib_dedupe.py
@@ -14,6 +14,7 @@ import bib_dedupe.maybe_cases
 import bib_dedupe.merge
 import bib_dedupe.prep
 from bib_dedupe import verbose_print
+from bib_dedupe.constants.fields import ORIGIN
 
 
 def prep(
@@ -147,6 +148,7 @@ def merge(
     matched_df: typing.Optional[pd.DataFrame] = None,
     duplicate_id_sets: typing.Optional[list] = None,
     verbosity_level: typing.Optional[int] = None,
+    origin_column: str = ORIGIN,
 ) -> pd.DataFrame:
     """
     Merges duplicate records in the given dataframe.
@@ -173,7 +175,9 @@ def merge(
         matched_df = match(blocked_df)
         duplicate_id_sets = bib_dedupe.cluster.get_connected_components(matched_df)
 
-    return bib_dedupe.merge.merge(records_df, duplicate_id_sets=duplicate_id_sets)
+    return bib_dedupe.merge.merge(
+        records_df, duplicate_id_sets=duplicate_id_sets, origin_column=origin_column
+    )
 
 
 def _download_file_from_github(url: str, local_path: str) -> None:

--- a/bib_dedupe/cli.py
+++ b/bib_dedupe/cli.py
@@ -1,19 +1,436 @@
-import click
+"""Command-line interface for :mod:`bib_dedupe`."""
+from __future__ import annotations
 
-import bib_dedupe.debug
+import argparse
+import sys
+from dataclasses import dataclass
+from importlib import metadata
+from pathlib import Path
+from typing import Optional
+from typing import Sequence
+
+import pandas as pd
+
+from bib_dedupe import cluster as _cluster
+from bib_dedupe import maybe_cases
+from bib_dedupe.bib_dedupe import block
+from bib_dedupe.bib_dedupe import export_maybe
+from bib_dedupe.bib_dedupe import import_maybe
+from bib_dedupe.bib_dedupe import match
+from bib_dedupe.bib_dedupe import merge
+from bib_dedupe.bib_dedupe import prep
 
 
-@click.group()
-def main() -> None:
-    """A simple CLI for bib_dedupe."""
-    pass
+class CLIError(Exception):
+    """Raised for command-line usage errors."""
 
 
-@main.command()
-@click.pass_context
-def debug(ctx: click.Context) -> None:
-    bib_dedupe.debug.debug()
+@dataclass
+class RuntimeOptions:
+    """Common runtime options passed to library functions."""
+
+    cpu: int
+    verbosity_level: Optional[int]
 
 
-if __name__ == "__main__":
-    main()
+DataFrame = pd.DataFrame
+
+
+def read_df(path: Path) -> DataFrame:
+    """Load a dataframe from *path* based on its file extension."""
+
+    if not path.exists():
+        raise CLIError(f"Input file not found: {path}")
+
+    suffix = path.suffix.lower()
+    try:
+        if suffix == ".csv":
+            return pd.read_csv(path, keep_default_na=False, low_memory=False)
+        if suffix in {".parquet", ".pq"}:
+            try:
+                return pd.read_parquet(path)
+            except ImportError as exc:  # pragma: no cover - depends on optional backend
+                raise CLIError(
+                    "Parquet support requires an optional dependency such as 'pyarrow'."
+                ) from exc
+        if suffix == ".json":
+            return pd.read_json(path)
+    except ValueError as exc:
+        raise CLIError(f"Failed to read {path}: {exc}") from exc
+
+    raise CLIError(
+        "Unsupported file extension for input. Supported extensions: .csv, .parquet, .json"
+    )
+
+
+def _ensure_output_path(path: Path) -> Path:
+    if path.suffix:
+        return path
+    return path.with_suffix(".csv")
+
+
+def write_df(df: DataFrame, path: Path) -> None:
+    """Persist *df* to *path*, inferring the format from the file suffix."""
+
+    output_path = _ensure_output_path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    suffix = output_path.suffix.lower()
+    if suffix == ".csv":
+        df.to_csv(output_path, index=False)
+        return
+    if suffix in {".parquet", ".pq"}:
+        try:
+            df.to_parquet(output_path, index=False)
+        except Exception as exc:  # pragma: no cover - backend availability specific
+            raise CLIError(
+                f"Failed to write parquet file {output_path}: {exc}"
+            ) from exc
+        return
+    if suffix == ".json":
+        df.to_json(output_path, orient="records", indent=2)
+        return
+
+    raise CLIError(
+        "Unsupported file extension for output. Supported extensions: .csv, .parquet, .json"
+    )
+
+
+def _resolve_verbosity(args: argparse.Namespace) -> Optional[int]:
+    verbosity_level = getattr(args, "verbosity_level", None)
+    quiet = getattr(args, "quiet", False)
+    verbose = getattr(args, "verbose", False)
+
+    if quiet and verbose:
+        raise CLIError("--quiet and --verbose cannot be used together.")
+
+    if quiet:
+        if verbosity_level is not None:
+            raise CLIError("--quiet cannot be combined with --verbosity-level.")
+        return 0
+    if verbose:
+        if verbosity_level is not None:
+            raise CLIError("--verbose cannot be combined with --verbosity-level.")
+        return 2
+    return verbosity_level
+
+
+def _collect_runtime_options(args: argparse.Namespace) -> RuntimeOptions:
+    cpu = getattr(args, "cpu", -1)
+    verbosity_level = _resolve_verbosity(args)
+    return RuntimeOptions(cpu=cpu, verbosity_level=verbosity_level)
+
+
+def _describe_maybe_cases() -> str:
+    path = Path(maybe_cases.MAYBE_CASES_FILEPATH)
+    if path.exists():
+        return f"Maybe cases exported to: {path.resolve()}"
+    return "No maybe cases were exported."
+
+
+def run_merge(args: argparse.Namespace) -> int:
+    options = _collect_runtime_options(args)
+    records_df = read_df(Path(args.input))
+    n_input = len(records_df)
+
+    matched_df: Optional[DataFrame] = None
+    duplicate_id_sets: Optional[list] = None
+    pairs_df: Optional[DataFrame] = None
+
+    if args.export_maybe:
+        prep_df = prep(
+            records_df, verbosity_level=options.verbosity_level, cpu=options.cpu
+        )
+        pairs_df = block(
+            prep_df, verbosity_level=options.verbosity_level, cpu=options.cpu
+        )
+        matched_df = match(
+            pairs_df, verbosity_level=options.verbosity_level, cpu=options.cpu
+        )
+        export_maybe(
+            records_df,
+            matched_df=matched_df,
+            verbosity_level=options.verbosity_level,
+        )
+        print(_describe_maybe_cases())
+        print(
+            "Review the exported maybe cases and rerun with --import-maybe to apply decisions."
+        )
+        return 0
+
+    if args.import_maybe:
+        prep_df = prep(
+            records_df, verbosity_level=options.verbosity_level, cpu=options.cpu
+        )
+        pairs_df = block(
+            prep_df, verbosity_level=options.verbosity_level, cpu=options.cpu
+        )
+        matched_df = match(
+            pairs_df, verbosity_level=options.verbosity_level, cpu=options.cpu
+        )
+        matched_df = import_maybe(matched_df, verbosity_level=options.verbosity_level)
+        duplicate_id_sets = _cluster.get_connected_components(matched_df)
+        merged_df = merge(
+            records_df,
+            duplicate_id_sets=duplicate_id_sets,
+            verbosity_level=options.verbosity_level,
+        )
+    else:
+        merged_df = merge(
+            records_df,
+            verbosity_level=options.verbosity_level,
+        )
+
+    write_df(merged_df, Path(args.output))
+
+    if args.stats:
+        stats_lines = [
+            f"Input records: {n_input}",
+            f"Merged records: {len(merged_df)}",
+        ]
+        if pairs_df is not None:
+            stats_lines.append(f"Blocked pairs: {len(pairs_df)}")
+        if matched_df is not None and "duplicate_label" in matched_df.columns:
+            label_counts = matched_df["duplicate_label"].value_counts()
+            n_true = int(label_counts.get("duplicate", 0))
+            n_maybe = int(label_counts.get("maybe", 0))
+            stats_lines.append(f"Confirmed matches: {n_true}")
+            stats_lines.append(f"Maybe matches: {n_maybe}")
+        print(" | ".join(stats_lines))
+
+    return 0
+
+
+def run_prep(args: argparse.Namespace) -> int:
+    options = _collect_runtime_options(args)
+    records_df = read_df(Path(args.input))
+    prepared_df = prep(
+        records_df, verbosity_level=options.verbosity_level, cpu=options.cpu
+    )
+    write_df(prepared_df, Path(args.output))
+    return 0
+
+
+def run_block(args: argparse.Namespace) -> int:
+    options = _collect_runtime_options(args)
+    records_df = read_df(Path(args.input))
+    pairs_df = block(
+        records_df, verbosity_level=options.verbosity_level, cpu=options.cpu
+    )
+    write_df(pairs_df, Path(args.output))
+    return 0
+
+
+def run_match(args: argparse.Namespace) -> int:
+    options = _collect_runtime_options(args)
+    pairs_df = read_df(Path(args.input))
+    matched_df = match(
+        pairs_df, verbosity_level=options.verbosity_level, cpu=options.cpu
+    )
+    write_df(matched_df, Path(args.output))
+
+    if args.export_maybe:
+        if not args.records:
+            raise CLIError(
+                "--export-maybe requires --records to provide the original records."
+            )
+        records_df = read_df(Path(args.records))
+        export_maybe(
+            records_df,
+            matched_df=matched_df,
+            verbosity_level=options.verbosity_level,
+        )
+        print(_describe_maybe_cases())
+
+    return 0
+
+
+def run_export_maybe(args: argparse.Namespace) -> int:
+    options = _collect_runtime_options(args)
+    records_df = read_df(Path(args.records))
+    matches_df = read_df(Path(args.matches))
+    export_maybe(
+        records_df,
+        matched_df=matches_df,
+        verbosity_level=options.verbosity_level,
+    )
+    print(_describe_maybe_cases())
+    return 0
+
+
+def run_import_maybe(args: argparse.Namespace) -> int:
+    options = _collect_runtime_options(args)
+    matches_df = read_df(Path(args.input))
+    updated_matches = import_maybe(matches_df, verbosity_level=options.verbosity_level)
+
+    if args.output:
+        write_df(updated_matches, Path(args.output))
+    else:
+        updated_matches.to_csv(sys.stdout, index=False)
+    return 0
+
+
+def run_version(_: argparse.Namespace) -> int:
+    try:
+        dist_version = metadata.version("bib-dedupe")
+    except metadata.PackageNotFoundError:
+        dist_version = "unknown"
+    print(dist_version)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="bib-dedupe",
+        description="Deduplicate bibliographic records from the command line.",
+    )
+
+    common_parser = argparse.ArgumentParser(add_help=False)
+    common_parser.add_argument(
+        "--verbosity-level", type=int, help="Override verbosity level."
+    )
+    common_parser.add_argument(
+        "-q", "--quiet", action="store_true", help="Silence verbose output."
+    )
+    common_parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Increase verbosity level."
+    )
+
+    cpu_parser = argparse.ArgumentParser(add_help=False)
+    cpu_parser.add_argument(
+        "--cpu",
+        type=int,
+        default=-1,
+        help="Number of CPUs to use (default: -1 for auto).",
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    merge_parser = subparsers.add_parser(
+        "merge",
+        parents=[common_parser, cpu_parser],
+        help="Run the full deduplication workflow and write merged records.",
+    )
+    merge_parser.add_argument(
+        "-i", "--input", required=True, help="Input records file path."
+    )
+    merge_parser.add_argument(
+        "-o", "--output", required=True, help="Output file path for merged records."
+    )
+    merge_parser.add_argument(
+        "--stats", action="store_true", help="Print a short statistics summary."
+    )
+    merge_parser.add_argument(
+        "--export-maybe",
+        action="store_true",
+        help="Export potential duplicates for manual review and exit.",
+    )
+    merge_parser.add_argument(
+        "--import-maybe",
+        action="store_true",
+        help="Re-import maybe decisions before merging.",
+    )
+    merge_parser.set_defaults(func=run_merge)
+
+    prep_parser = subparsers.add_parser(
+        "prep",
+        parents=[common_parser, cpu_parser],
+        help="Preprocess records before blocking.",
+    )
+    prep_parser.add_argument(
+        "-i", "--input", required=True, help="Input records file path."
+    )
+    prep_parser.add_argument(
+        "-o", "--output", required=True, help="Output file path for prepared records."
+    )
+    prep_parser.set_defaults(func=run_prep)
+
+    block_parser = subparsers.add_parser(
+        "block",
+        parents=[common_parser, cpu_parser],
+        help="Generate candidate record pairs for matching.",
+    )
+    block_parser.add_argument(
+        "-i", "--input", required=True, help="Input preprocessed records file path."
+    )
+    block_parser.add_argument(
+        "-o", "--output", required=True, help="Output file path for blocked pairs."
+    )
+    block_parser.set_defaults(func=run_block)
+
+    match_parser = subparsers.add_parser(
+        "match",
+        parents=[common_parser, cpu_parser],
+        help="Score candidate pairs and classify matches.",
+    )
+    match_parser.add_argument(
+        "-i", "--input", required=True, help="Input candidate pairs file path."
+    )
+    match_parser.add_argument(
+        "-o", "--output", required=True, help="Output file path for match decisions."
+    )
+    match_parser.add_argument(
+        "--export-maybe",
+        action="store_true",
+        help="Export maybe cases immediately after matching.",
+    )
+    match_parser.add_argument(
+        "--records",
+        help="Records file path required when using --export-maybe.",
+    )
+    match_parser.set_defaults(func=run_match)
+
+    export_maybe_parser = subparsers.add_parser(
+        "export-maybe",
+        parents=[common_parser],
+        help="Export maybe cases for manual review.",
+    )
+    export_maybe_parser.add_argument(
+        "--records", required=True, help="Path to the records file."
+    )
+    export_maybe_parser.add_argument(
+        "--matches", required=True, help="Path to the matches file."
+    )
+    export_maybe_parser.set_defaults(func=run_export_maybe)
+
+    import_maybe_parser = subparsers.add_parser(
+        "import-maybe",
+        parents=[common_parser],
+        help="Apply manual maybe decisions to match results.",
+    )
+    import_maybe_parser.add_argument(
+        "-i", "--input", required=True, help="Matches file containing maybe decisions."
+    )
+    import_maybe_parser.add_argument(
+        "-o", "--output", help="Optional output path for updated matches."
+    )
+    import_maybe_parser.set_defaults(func=run_import_maybe)
+
+    version_parser = subparsers.add_parser(
+        "version", help="Print the installed bib-dedupe version."
+    )
+    version_parser.set_defaults(func=run_version)
+
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return 0
+
+    try:
+        return args.func(args)
+    except CLIError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:  # pragma: no cover - safeguard for unexpected failures
+        print(f"Unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    sys.exit(main())

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -6,6 +6,12 @@ entry point. The CLI layers structured subcommands on top of the library
 functions in :mod:`bib_dedupe.bib_dedupe` and aims to provide an ergonomic
 wrapper for common workflows.
 
+To use the cli, install bib-dedupe with the cli option:
+
+.. code-block:: bash
+
+   pip install bib-dedupe[cli]
+
 Quick reference
 ---------------
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,84 @@
+Command-line interface
+======================
+
+BibDedupe exposes its deduplication pipeline through the :command:`bib-dedupe`
+entry point. The CLI layers structured subcommands on top of the library
+functions in :mod:`bib_dedupe.bib_dedupe` and aims to provide an ergonomic
+wrapper for common workflows.
+
+Quick reference
+---------------
+
+.. code-block:: bash
+
+   # merge records in one go
+   bib-dedupe merge -i records.csv -o merged.csv
+
+   # run the pipeline step by step
+   bib-dedupe prep -i records.csv -o records.prep.csv
+   bib-dedupe block -i records.prep.csv -o pairs.csv
+   bib-dedupe match -i pairs.csv -o matches.csv
+
+   # export maybe cases for manual review
+   bib-dedupe match -i pairs.csv -o matches.csv --export-maybe --records records.csv
+   # review the generated maybe_cases.csv file, then
+   bib-dedupe import-maybe -i matches.csv -o matches.reviewed.csv
+   bib-dedupe merge -i records.csv -o merged.csv --import-maybe
+
+Input and output formats
+------------------------
+
+The CLI inspects file extensions to determine how to load or persist
+:class:`pandas.DataFrame` objects. CSV is supported out of the box. Parquet files
+(``.parquet`` or ``.pq``) are supported when an appropriate pandas backend (for
+example ``pyarrow``) is installed. JSON files are read and written in ``records``
+orientation. Unknown extensions trigger a helpful error and non-zero exit code.
+
+Subcommands
+-----------
+
+``merge``
+   Execute the full pipeline and write merged records. Optional flags include
+   ``--stats`` (print pipeline statistics), ``--export-maybe`` (export uncertain
+   pairs for manual review), ``--import-maybe`` (apply decisions captured in
+   :mod:`bib_dedupe.maybe_cases`).
+
+``prep``
+   Run :func:`bib_dedupe.bib_dedupe.prep` on an input dataset and write the
+   prepared records.
+
+``block``
+   Produce candidate record pairs via :func:`bib_dedupe.bib_dedupe.block`.
+
+``match``
+   Score blocked pairs with :func:`bib_dedupe.bib_dedupe.match`. Accepts
+   ``--export-maybe`` to immediately write maybe cases (requires ``--records`` to
+   supply the original dataset).
+
+``export-maybe``
+   Call :func:`bib_dedupe.bib_dedupe.export_maybe` on explicit records and match
+   files. Useful for re-running the export without recomputing matches.
+
+``import-maybe``
+   Apply manually reviewed maybe cases using
+   :func:`bib_dedupe.bib_dedupe.import_maybe`. When ``-o/--output`` is omitted
+   the updated matches are emitted to ``stdout``.
+
+``version``
+   Print the installed BibDedupe package version.
+
+Common options
+--------------
+
+* ``--cpu`` controls how many CPUs the underlying functions may use. ``-1`` is
+  the default and lets the library pick an appropriate value.
+* ``--verbosity-level`` passes through the exact verbosity value expected by the
+  library. ``-q/--quiet`` maps to level ``0`` and ``-v/--verbose`` maps to level
+  ``2`` for convenience. These flags are mutually exclusive.
+
+Error handling and exit codes
+-----------------------------
+
+Usage issues (for example missing files or incompatible flag combinations)
+raise friendly error messages and exit with status code ``2``. Unexpected
+runtime failures exit with status ``1`` after printing the exception message.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,6 +87,32 @@ For advanced use cases, it is also possible to complete and customize each step 
 
 .. _Python scripts: installation#starting-bib-dedupe
 
+Command-line interface
+----------------------
+
+In addition to the Python APIs, BibDedupe provides a `bib-dedupe` console command that orchestrates the full deduplication workflow or individual pipeline stages. Typical usage looks like this:
+
+.. code-block:: bash
+
+   # install once
+   pip install bib-dedupe
+
+   # end-to-end merge
+   bib-dedupe merge -i records.csv -o merged.csv --stats
+
+   # stepwise execution
+   bib-dedupe prep -i records.csv -o records.prep.csv
+   bib-dedupe block -i records.prep.csv -o pairs.csv
+   bib-dedupe match -i pairs.csv -o matches.csv
+
+   # review and apply maybe cases
+   bib-dedupe match -i pairs.csv -o matches.csv --export-maybe --records records.csv
+   # edit the generated maybe_cases.csv, then
+   bib-dedupe import-maybe -i matches.csv -o matches.reviewed.csv
+   bib-dedupe merge -i records.csv -o merged.csv --import-maybe
+
+Refer to :doc:`cli` for a detailed explanation of the available subcommands and options.
+
 .. toctree::
    :hidden:
    :maxdepth: 2
@@ -94,4 +120,5 @@ For advanced use cases, it is also possible to complete and customize each step 
 
    installation
    usage
+   cli
    api

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
 "Documentation" = "https://colrev-environment.github.io/bib-dedupe/"
 
 [project.optional-dependencies]
+cli = [
+    "colrev>=0.15.0",
+]
 with-data = [
     "asreview>=1.5",
     "asreview-datatools",

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -42,7 +42,7 @@ def example_records(tmp_path: Path) -> Path:
 
     repo_root = Path(__file__).resolve().parents[1]
     local_copy = tmp_path / "stroke.csv"
-    shutil.copy(repo_root / "data" / "stroke" / "records_pre_merged.csv", local_copy)
+    shutil.copy(repo_root / "tests" / "ldd-full-benchmark" / "stroke" / "records_pre_merged.csv", local_copy)
 
     with working_directory(tmp_path):
         df = load_example_data("stroke")

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,5 +1,4 @@
 """Integration tests for the bib-dedupe command line interface."""
-
 from __future__ import annotations
 
 import os

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,128 @@
+"""Integration tests for the bib-dedupe command line interface."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from bib_dedupe.bib_dedupe import load_example_data
+
+
+@contextmanager
+def working_directory(path: Path) -> None:
+    """Temporarily change the working directory for the duration of a context."""
+
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def run_cli(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[bytes]:
+    """Execute the CLI using ``python -m bib_dedupe.cli`` within *tmp_path*."""
+
+    env = os.environ.copy()
+    repo_root = Path(__file__).resolve().parents[1]
+    env["PYTHONPATH"] = str(repo_root) + os.pathsep + env.get("PYTHONPATH", "")
+    cmd = [sys.executable, "-m", "bib_dedupe.cli", *args]
+    return subprocess.run(cmd, cwd=tmp_path, env=env, check=True, capture_output=True)
+
+
+@pytest.fixture()
+def example_records(tmp_path: Path) -> Path:
+    """Prepare example stroke records for use in CLI tests."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    local_copy = tmp_path / "stroke.csv"
+    shutil.copy(repo_root / "data" / "stroke" / "records_pre_merged.csv", local_copy)
+
+    with working_directory(tmp_path):
+        df = load_example_data("stroke")
+
+    if "container_title" not in df.columns:
+        df["container_title"] = df.get("journal", "")
+    if "doi" not in df.columns:
+        df["doi"] = ""
+    if "abstract" not in df.columns:
+        df["abstract"] = ""
+
+    records_path = tmp_path / "records.csv"
+    df.to_csv(records_path, index=False)
+    return records_path
+
+
+def test_merge_end_to_end(tmp_path: Path, example_records: Path) -> None:
+    merged_path = tmp_path / "merged.csv"
+    run_cli(tmp_path, "merge", "-i", str(example_records), "-o", str(merged_path))
+
+    assert merged_path.exists()
+    merged_df = pd.read_csv(merged_path)
+    input_df = pd.read_csv(example_records)
+    assert 0 < len(merged_df) <= len(input_df)
+
+
+def test_stepwise_pipeline(tmp_path: Path, example_records: Path) -> None:
+    prep_path = tmp_path / "prep.csv"
+    block_path = tmp_path / "pairs.csv"
+    match_path = tmp_path / "matches.csv"
+    match_maybe_path = tmp_path / "matches_with_maybe.csv"
+    imported_path = tmp_path / "matches_imported.csv"
+    merged_path = tmp_path / "merged_after_import.csv"
+
+    run_cli(tmp_path, "prep", "-i", str(example_records), "-o", str(prep_path))
+    run_cli(tmp_path, "block", "-i", str(prep_path), "-o", str(block_path))
+    run_cli(tmp_path, "match", "-i", str(block_path), "-o", str(match_path))
+
+    prep_df = pd.read_csv(prep_path)
+    assert {"ID", "title"}.issubset(set(prep_df.columns))
+
+    pairs_df = pd.read_csv(block_path)
+    assert {"ID_1", "ID_2"}.issubset(set(pairs_df.columns))
+
+    matches_df = pd.read_csv(match_path)
+    assert "duplicate_label" in {col.lower() for col in matches_df.columns}
+
+    run_cli(
+        tmp_path,
+        "match",
+        "-i",
+        str(block_path),
+        "-o",
+        str(match_maybe_path),
+        "--export-maybe",
+        "--records",
+        str(example_records),
+    )
+
+    maybe_file = tmp_path / "maybe_cases.csv"
+    assert maybe_file.exists()
+
+    run_cli(
+        tmp_path,
+        "import-maybe",
+        "-i",
+        str(match_maybe_path),
+        "-o",
+        str(imported_path),
+    )
+    assert imported_path.exists()
+
+    run_cli(
+        tmp_path,
+        "merge",
+        "-i",
+        str(example_records),
+        "-o",
+        str(merged_path),
+        "--import-maybe",
+    )
+    assert merged_path.exists()


### PR DESCRIPTION
This PR introduces cli operations for bib-dedupe:

```sh
 # end-to-end merge
 bib-dedupe merge -i records.csv -o merged.csv --stats

 # stepwise execution
 bib-dedupe prep -i records.csv -o records.prep.csv
 bib-dedupe block -i records.prep.csv -o pairs.csv
 bib-dedupe match -i pairs.csv -o matches.csv

 # review and apply maybe cases
 bib-dedupe match -i pairs.csv -o matches.csv --export-maybe --records records.csv
 # edit the generated maybe_cases.csv, then
 bib-dedupe import-maybe -i matches.csv -o matches.reviewed.csv
 bib-dedupe merge -i records.csv -o merged.csv --import-maybe
```

TODO:

- Loading and saving BibTeX requires an external library (e.g., colrev).
- TODO : remove the step-by-step option and only offer the straight-through option (intermediate results would be kept in memory anyway)