### PR TITLE
Switch docs theme to sphinx_rtd_theme and add logo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@ extensions = ["sphinx.ext.autodoc", "sphinx_copybutton"]
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "furo"
+html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
 html_title = "BibDedupe"
+html_logo = "figures/logo.png"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,8 @@
+
+.. image:: figures/logo.png
+   :alt: BibDedupe logo
+   :align: center
+
 BibDedupe Documentation
 ======================================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "pytest-skip-slow>=0.0.5",
 ]
 docs = [
-    "furo>=2024.8.0",
+    "sphinx-rtd-theme>=3.0.0",
     "sphinx-copybutton>=0.5.2",
 ]
 


### PR DESCRIPTION
## Summary
- switch the documentation theme to sphinx_rtd_theme and configure the project logo in the Sphinx HTML settings
- add the BibDedupe logo image to the top of the documentation landing page
- update the docs optional dependency set to include sphinx-rtd-theme instead of furo

## Testing
- `pip install -e .[docs]`
- `make -C docs html`


------
https://chatgpt.com/codex/tasks/task_e_68ca9d08d944832a93d1fce4fe7b009b